### PR TITLE
Add switch screen function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -111,6 +111,10 @@ var showSavedPostersButton = document.querySelector('.show-saved')
 var backToMainButton = document.querySelector('.back-to-main')
 var showMyPosterButton = document.querySelector('.make-poster')
 
+var posterFormView = document.querySelector('.poster-form')
+var savedPostersView = document.querySelector('.saved-posters')
+var mainPosterView = document.querySelector('.main-poster')
+
 var mainTitle = document.querySelector('.poster-title')
 var mainImageURL = document.querySelector('.poster-img')
 var mainQuote = document.querySelector('.poster-quote')
@@ -141,21 +145,22 @@ showMyPosterButton.addEventListener('click', function() {
 
   event.preventDefault()
   displayPoster()
-  posterFormToggle()
+  switchScreens(mainPosterView, savedPostersView)
 })
 
-posterFormButton.addEventListener('click', posterFormToggle)
-posterFormBackButton.addEventListener('click', posterFormToggle)
+posterFormButton.addEventListener('click', function() {
+  switchScreens(mainPosterView, posterFormView)})
+
+posterFormBackButton.addEventListener('click', function() {
+  switchScreens(mainPosterView, posterFormView)})
 
 backToMainButton.addEventListener('click', function() {
-  savedPostersToggle()
+  switchScreens(mainPosterView, savedPostersView)
   posterGrid.innerHTML = ``
 })
 
-
-
 showSavedPostersButton.addEventListener('click', function() {
-  savedPostersToggle()
+  switchScreens(mainPosterView, savedPostersView)
   for (var i = 0; i < savedPosters.length; i++) {
     posterGrid.innerHTML += `
     <article class="mini-poster" id=${savedPosters[i].id}>
@@ -218,12 +223,7 @@ function randomPoster() {
   currentPoster = new Poster(imageURL, title, quote)
 }
 
-function posterFormToggle() {
-  document.querySelector('.main-poster').classList.toggle('hidden')
-  document.querySelector('.poster-form').classList.toggle('hidden')
-}
-
-function savedPostersToggle() {
-  document.querySelector('.main-poster').classList.toggle('hidden')
-  document.querySelector('.saved-posters').classList.toggle('hidden')
+function switchScreens(mainScreen, alternateScreen) {
+  mainPosterView.classList.toggle('hidden')
+  alternateScreen.classList.toggle('hidden')
 }


### PR DESCRIPTION
## *Purpose:*
*What does this merge do? Check all that apply.*
- [ ] Adds a new feature
- [x] Improves an existing feature
- [ ] Fixes a bug
- [x] Cleans up (logs, tests, etc.)



## *Description:*
Combined two functions for switching between screens into one function



## *Issues:*
There is one known bug:
When switching from the poster form screen by using the show my poster button, and then clicking on the show saved posters button, the user is taken back to the poster form view rather than the poster grid view.



## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have used tests to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my change

